### PR TITLE
Export for CommonJS & Node v14 Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 [![NPM](https://nodei.co/npm/yiff.png)](https://nodei.co/npm/yiff/)
 
 ## **VERSION 3 IS A BREAKING CHANGE**
+## NodeJS V14 or higher is required!
 
 ### **\*Do not** update from v2 if your current code is still based on v2\*
 
 If you need Support or want more Information, join [my discord server](https://discord.gg/He2822y "a link to my discord server")
+
 
 ## ⭐️ Supported APIs
 

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import { config } from "./src/types";
 import consts from "./src/consts";
 import request from "./src/request";
 
-export default class Yiff {
+class Yiff {
     private config: config
     private useragent: string
     private killswitch: { enabled: boolean, instance: string }
@@ -198,3 +198,4 @@ export default class Yiff {
 }
 
 module.exports = Yiff
+export default Yiff

--- a/index.ts
+++ b/index.ts
@@ -197,3 +197,4 @@ export default class Yiff {
 
 }
 
+module.exports = Yiff

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   },
   "devDependencies": {
     "typescript": "^4.2.3"
+  },
+  "engines": {
+    "node": ">=14"
   }
 }


### PR DESCRIPTION
This pull request adds support for using `require` in commonjs modules (exporting on `module.exports`), and adds a notice in the readme, as well as in the package file (will show when installing) for the minimum required node version.